### PR TITLE
fix: include the requirement of having a schema in the different manifests.

### DIFF
--- a/latest/cutekit.manifest.component
+++ b/latest/cutekit.manifest.component
@@ -5,7 +5,8 @@
     "type": "object",
     "required": [
         "id",
-        "type"
+        "type",
+        "$schema"
     ],
     "additionalProperties": false,
     "properties": {

--- a/latest/cutekit.manifest.component
+++ b/latest/cutekit.manifest.component
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1",
+    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.component",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A representation of a component manifest for CuteKit",
     "type": "object",
@@ -12,7 +12,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.component"
         },
         "id": {
             "description": "The unique identifier for this manifest",

--- a/latest/cutekit.manifest.project
+++ b/latest/cutekit.manifest.project
@@ -3,6 +3,9 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A representation of a component project for CuteKit",
     "type": "object",
+    "required": [
+        "$schema"
+    ],
     "additionalProperties": false,
     "properties": {
         "$schema": {

--- a/latest/cutekit.manifest.project
+++ b/latest/cutekit.manifest.project
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.project.v1",
+    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.project",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A representation of a component project for CuteKit",
     "type": "object",
@@ -10,7 +10,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.project"
         },
         "id": {
             "description": "The unique identifier for this manifest",

--- a/latest/cutekit.manifest.target
+++ b/latest/cutekit.manifest.target
@@ -4,6 +4,9 @@
     "description": "A representation of a target manifest for CuteKit",
     "type": "object",
     "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",

--- a/latest/cutekit.manifest.target
+++ b/latest/cutekit.manifest.target
@@ -1,5 +1,5 @@
 {
-    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1",
+    "$id": "https://schemas.cute.engineering/stable/cutekit.manifest.target",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A representation of a target manifest for CuteKit",
     "type": "object",
@@ -10,7 +10,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.target"
         },
         "id": {
             "description": "The unique identifier for this manifest",

--- a/stable/cutekit.manifest.component.v1
+++ b/stable/cutekit.manifest.component.v1
@@ -5,7 +5,8 @@
     "type": "object",
     "required": [
         "id",
-        "type"
+        "type",
+        "$schema"
     ],
     "additionalProperties": false,
     "properties": {

--- a/stable/cutekit.manifest.component.v1
+++ b/stable/cutekit.manifest.component.v1
@@ -12,7 +12,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.component.v1"
         },
         "id": {
             "description": "The unique identifier for this manifest",

--- a/stable/cutekit.manifest.project.v1
+++ b/stable/cutekit.manifest.project.v1
@@ -3,6 +3,9 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "A representation of a component project for CuteKit",
     "type": "object",
+    "required": [
+        "$schema"
+    ],
     "additionalProperties": false,
     "properties": {
         "$schema": {

--- a/stable/cutekit.manifest.project.v1
+++ b/stable/cutekit.manifest.project.v1
@@ -10,7 +10,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.project.v1"
         },
         "id": {
             "description": "The unique identifier for this manifest",

--- a/stable/cutekit.manifest.target.v1
+++ b/stable/cutekit.manifest.target.v1
@@ -4,6 +4,9 @@
     "description": "A representation of a target manifest for CuteKit",
     "type": "object",
     "additionalProperties": false,
+    "required": [
+        "$schema"
+    ],
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",

--- a/stable/cutekit.manifest.target.v1
+++ b/stable/cutekit.manifest.target.v1
@@ -10,7 +10,7 @@
     "properties": {
         "$schema": {
             "description": "The schema that this manifest conforms to",
-            "type": "string"
+            "const": "https://schemas.cute.engineering/stable/cutekit.manifest.target.v1"
         },
         "id": {
             "description": "The unique identifier for this manifest",


### PR DESCRIPTION
Because ck expect the file to have `$schema` in the json file. So the schema must expect its value.
This may be usefull if we want to create a vscode extension that notifies the user when he don't use `$schema`. 